### PR TITLE
Various fixups; drop support for Python 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="HTCondor REST Daemon dev/test image"
 LABEL org.opencontainers.image.vendor=""
 RUN mkdir -p /usr/local/src
-COPY . /usr/local/src/htcondor-restd/
+RUN install -d -o restd -g restd /usr/local/src/htcondor-restd
+COPY --chown=restd . /usr/local/src/htcondor-restd/
 # Check how the RESTD was installed into the minicondor image.
 # If the RESTD has been installed in a virtualenv owned by the restd user, then
 # we need to install the new version in the same virtualenv.
@@ -12,9 +13,7 @@ RUN if [ -e /home/restd/htcondor-restd/bin/activate ]; then \
         runuser restd bash -c " \
             . /home/restd/htcondor-restd/bin/activate && \
             # copy everything to a dir restd has write permissions to \
-            cp -r /usr/local/src/htcondor-restd /var/tmp/htcondor-restd && \
-            python3 -mpip install --upgrade /var/tmp/htcondor-restd  && \
-            rm -rf /var/tmp/htcondor-restd \
+            python3 -mpip install --upgrade /usr/local/src/htcondor-restd \
         "; \
     else \
         $(command -v pip-3 || command -v pip3) install --upgrade /usr/local/src/htcondor-restd; \

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Installation
 Installation requires the following Python modules:
 
 - `htcondor >= 10.0.0`
-- `flask`
-- `flask-restful`
+- `flask 3.x`
+- `flask-restful 0.3.10`
 
 Install them via `pip` or your OS's package manager.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 Installation requires the following Python modules:
 
 - `htcondor >= 10.0.0`
-- `flask 3.x`
+- `flask 2+`
 - `flask-restful 0.3.10`
 
 Install them via `pip` or your OS's package manager.

--- a/condor_restd/__init__.py
+++ b/condor_restd/__init__.py
@@ -48,7 +48,7 @@ app.logger.info("Using HTCondor Python bindings version %d", BINDINGS_VERSION)
 
 @api.representation("application/json")
 def output_json(data, code, headers=None):
-    resp = make_response(json.dumps(data), code)
+    resp = make_response(json.dumps(data) + "\n", code)
     resp.headers.extend(headers or {})
     resp.headers["Access-Control-Allow-Origin"] = "*"
     return resp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask == 3.*
+flask >= 2.0.0
 flask-restful == 0.3.10
 htcondor >= 10.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask >= 2.0.0
 flask-restful == 0.3.10
 htcondor >= 10.0.0
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask
+flask == 3.*
 flask-restful == 0.3.10
 htcondor >= 10.0.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "flask==3.*",
+        "flask>=2.0.0",
         "flask-restful==0.3.10",
         "htcondor>=10.0.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,14 @@ from setuptools import setup
 
 setup(
     name="HTCondor-RESTD",
-    version="0.200924",
+    version="0.240508",
     long_description=__doc__,
     packages=["condor_restd"],
     include_package_data=True,
     zip_safe=False,
-    install_requires=["flask", "flask-restful", "htcondor>=8.9.2"],
+    install_requires=[
+        "flask==3.*",
+        "flask-restful==0.3.10",
+        "htcondor>=10.0.0",
+    ],
 )


### PR DESCRIPTION
- Set the required major version of Flask to 2. *This means Python 2 is no longer supported.*
- Add a trailing newline to the output to make it less annoying
- dev image: make /usr/local/src/htcondor-restd owned by the restd user
- Add missing requirement